### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,5 @@ author=Joan Ortega
 maintainer=Joan Ortega <jomaora@gmail.com>
 sentence=Ethernet Client and Server HTTP library
 paragraph=A basic library to handle a Client HTTP and a Server HTTP using an Arduino UNO and an Ethernet Shield.
-category=IoT
+category=Communication
 url=https://github.com/jomaora/schapiuino.git


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'IoT' in library schapiuino is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format